### PR TITLE
#25: Setup author/slug permalinks.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,10 @@ function App() {
           <Header />
           <Routes>
             <Route path="/" element={<Home />} />
-            <Route path="/quote/:id" element={<ViewQuote />} />
+            <Route
+              path="/:authorPermalink/:quotePermalink"
+              element={<ViewQuote />}
+            />
             <Route path="/not-found" element={<NotFound />} />
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -59,3 +59,18 @@ export const GET_PREVIOUS_QUOTE = gql`
     }
   }
 `;
+
+export const GET_QUOTE_BY_PERMALINK = gql`
+  query GetQuoteByPermalink($author: String!, $permalink: String!) {
+    quoteByPermalink(author: $author, permalink: $permalink) {
+      id
+      quote
+      permalink
+      author {
+        id
+        name
+        permalink
+      }
+    }
+  }
+`;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export { useRandomQuote } from './useRandomQuote';
 export { useQuoteById } from './useQuoteById';
+export { useQuoteByPermalink } from './useQuoteByPermalink';
 export { useNextQuote } from './useNextQuote';
 export { usePreviousQuote } from './usePreviousQuote';

--- a/src/hooks/useQuoteByPermalink.test.tsx
+++ b/src/hooks/useQuoteByPermalink.test.tsx
@@ -1,0 +1,404 @@
+import React, { ReactNode } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { MockedProvider } from '@apollo/client/testing';
+
+import { useQuoteByPermalink } from './useQuoteByPermalink';
+import { GET_QUOTE_BY_PERMALINK } from '../graphql/queries';
+
+const mockQuote = {
+  id: '1',
+  quote: 'The only way to do great work is to love what you do.',
+  permalink: 'test-quote',
+  author: {
+    id: '1',
+    name: 'Steve Jobs',
+    permalink: 'steve-jobs',
+  },
+};
+
+describe('useQuoteByPermalink', () => {
+  describe('Valid Permalinks', () => {
+    it('should return loading state initially', () => {
+      const mocks = [
+        {
+          request: {
+            query: GET_QUOTE_BY_PERMALINK,
+            variables: { author: 'steve-jobs', permalink: 'test-quote' },
+          },
+          result: {
+            data: {
+              quoteByPermalink: mockQuote,
+            },
+          },
+        },
+      ];
+
+      const wrapper = ({ children }: { children: ReactNode }) => (
+        <MockedProvider mocks={mocks}>{children}</MockedProvider>
+      );
+
+      const { result } = renderHook(
+        () => useQuoteByPermalink('steve-jobs', 'test-quote'),
+        { wrapper }
+      );
+
+      expect(result.current.loading).toBe(true);
+      expect(result.current.quote).toBeUndefined();
+      expect(result.current.error).toBeUndefined();
+    });
+
+    it('should return quote data after loading', async () => {
+      const mocks = [
+        {
+          request: {
+            query: GET_QUOTE_BY_PERMALINK,
+            variables: { author: 'steve-jobs', permalink: 'test-quote' },
+          },
+          result: {
+            data: {
+              quoteByPermalink: mockQuote,
+            },
+          },
+        },
+      ];
+
+      const wrapper = ({ children }: { children: ReactNode }) => (
+        <MockedProvider mocks={mocks}>{children}</MockedProvider>
+      );
+
+      const { result } = renderHook(
+        () => useQuoteByPermalink('steve-jobs', 'test-quote'),
+        { wrapper }
+      );
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.quote).toEqual(mockQuote);
+      expect(result.current.error).toBeUndefined();
+    });
+
+    it('should fetch quote with different permalinks', async () => {
+      const anotherMockQuote = {
+        id: '2',
+        quote: 'Another quote',
+        permalink: 'another-quote',
+        author: {
+          id: '2',
+          name: 'Author Name',
+          permalink: 'author-name',
+        },
+      };
+
+      const mocks = [
+        {
+          request: {
+            query: GET_QUOTE_BY_PERMALINK,
+            variables: { author: 'author-name', permalink: 'another-quote' },
+          },
+          result: {
+            data: {
+              quoteByPermalink: anotherMockQuote,
+            },
+          },
+        },
+      ];
+
+      const wrapper = ({ children }: { children: ReactNode }) => (
+        <MockedProvider mocks={mocks}>{children}</MockedProvider>
+      );
+
+      const { result } = renderHook(
+        () => useQuoteByPermalink('author-name', 'another-quote'),
+        { wrapper }
+      );
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.quote).toEqual(anotherMockQuote);
+      expect(result.current.error).toBeUndefined();
+    });
+  });
+
+  describe('Missing Permalinks', () => {
+    it('should skip query when author permalink is undefined', () => {
+      const wrapper = ({ children }: { children: ReactNode }) => (
+        <MockedProvider mocks={[]}>{children}</MockedProvider>
+      );
+
+      const { result } = renderHook(
+        () => useQuoteByPermalink(undefined, 'test-quote'),
+        { wrapper }
+      );
+
+      expect(result.current.loading).toBe(false);
+      expect(result.current.quote).toBeUndefined();
+      expect(result.current.error).toBeUndefined();
+    });
+
+    it('should skip query when quote permalink is undefined', () => {
+      const wrapper = ({ children }: { children: ReactNode }) => (
+        <MockedProvider mocks={[]}>{children}</MockedProvider>
+      );
+
+      const { result } = renderHook(
+        () => useQuoteByPermalink('steve-jobs', undefined),
+        { wrapper }
+      );
+
+      expect(result.current.loading).toBe(false);
+      expect(result.current.quote).toBeUndefined();
+      expect(result.current.error).toBeUndefined();
+    });
+
+    it('should skip query when both permalinks are undefined', () => {
+      const wrapper = ({ children }: { children: ReactNode }) => (
+        <MockedProvider mocks={[]}>{children}</MockedProvider>
+      );
+
+      const { result } = renderHook(
+        () => useQuoteByPermalink(undefined, undefined),
+        { wrapper }
+      );
+
+      expect(result.current.loading).toBe(false);
+      expect(result.current.quote).toBeUndefined();
+      expect(result.current.error).toBeUndefined();
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should return error when GraphQL query fails', async () => {
+      const mocks = [
+        {
+          request: {
+            query: GET_QUOTE_BY_PERMALINK,
+            variables: { author: 'steve-jobs', permalink: 'test-quote' },
+          },
+          error: new Error('GraphQL error'),
+        },
+      ];
+
+      const wrapper = ({ children }: { children: ReactNode }) => (
+        <MockedProvider mocks={mocks}>{children}</MockedProvider>
+      );
+
+      const { result } = renderHook(
+        () => useQuoteByPermalink('steve-jobs', 'test-quote'),
+        { wrapper }
+      );
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.error).toBeDefined();
+      expect(result.current.quote).toBeUndefined();
+    });
+
+    it('should handle network errors', async () => {
+      const mocks = [
+        {
+          request: {
+            query: GET_QUOTE_BY_PERMALINK,
+            variables: { author: 'steve-jobs', permalink: 'test-quote' },
+          },
+          error: new Error('Network error'),
+        },
+      ];
+
+      const wrapper = ({ children }: { children: ReactNode }) => (
+        <MockedProvider mocks={mocks}>{children}</MockedProvider>
+      );
+
+      const { result } = renderHook(
+        () => useQuoteByPermalink('steve-jobs', 'test-quote'),
+        { wrapper }
+      );
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.error).toBeDefined();
+      expect(result.current.quote).toBeUndefined();
+    });
+  });
+
+  describe('Quote Not Found', () => {
+    it('should return null when quote is not found', async () => {
+      const mocks = [
+        {
+          request: {
+            query: GET_QUOTE_BY_PERMALINK,
+            variables: {
+              author: 'nonexistent-author',
+              permalink: 'nonexistent-quote',
+            },
+          },
+          result: {
+            data: {
+              quoteByPermalink: null,
+            },
+          },
+        },
+      ];
+
+      const wrapper = ({ children }: { children: ReactNode }) => (
+        <MockedProvider mocks={mocks}>{children}</MockedProvider>
+      );
+
+      const { result } = renderHook(
+        () => useQuoteByPermalink('nonexistent-author', 'nonexistent-quote'),
+        { wrapper }
+      );
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.quote).toBeNull();
+      expect(result.current.error).toBeUndefined();
+    });
+
+    it('should return null when author exists but quote does not', async () => {
+      const mocks = [
+        {
+          request: {
+            query: GET_QUOTE_BY_PERMALINK,
+            variables: {
+              author: 'steve-jobs',
+              permalink: 'nonexistent-quote',
+            },
+          },
+          result: {
+            data: {
+              quoteByPermalink: null,
+            },
+          },
+        },
+      ];
+
+      const wrapper = ({ children }: { children: ReactNode }) => (
+        <MockedProvider mocks={mocks}>{children}</MockedProvider>
+      );
+
+      const { result } = renderHook(
+        () => useQuoteByPermalink('steve-jobs', 'nonexistent-quote'),
+        { wrapper }
+      );
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.quote).toBeNull();
+      expect(result.current.error).toBeUndefined();
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should handle permalinks with special characters', async () => {
+      const specialQuote = {
+        id: '3',
+        quote: 'Quote with special chars',
+        permalink: 'quote-with-special-chars',
+        author: {
+          id: '3',
+          name: 'Author',
+          permalink: 'author-with-special-chars',
+        },
+      };
+
+      const mocks = [
+        {
+          request: {
+            query: GET_QUOTE_BY_PERMALINK,
+            variables: {
+              author: 'author-with-special-chars',
+              permalink: 'quote-with-special-chars',
+            },
+          },
+          result: {
+            data: {
+              quoteByPermalink: specialQuote,
+            },
+          },
+        },
+      ];
+
+      const wrapper = ({ children }: { children: ReactNode }) => (
+        <MockedProvider mocks={mocks}>{children}</MockedProvider>
+      );
+
+      const { result } = renderHook(
+        () =>
+          useQuoteByPermalink(
+            'author-with-special-chars',
+            'quote-with-special-chars'
+          ),
+        { wrapper }
+      );
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.quote).toEqual(specialQuote);
+      expect(result.current.error).toBeUndefined();
+    });
+
+    it('should handle very long permalinks', async () => {
+      const longQuote = {
+        id: '4',
+        quote: 'Long quote',
+        permalink: 'this-is-a-very-long-quote-permalink-with-many-words',
+        author: {
+          id: '4',
+          name: 'Author',
+          permalink: 'this-is-a-very-long-author-permalink',
+        },
+      };
+
+      const mocks = [
+        {
+          request: {
+            query: GET_QUOTE_BY_PERMALINK,
+            variables: {
+              author: 'this-is-a-very-long-author-permalink',
+              permalink: 'this-is-a-very-long-quote-permalink-with-many-words',
+            },
+          },
+          result: {
+            data: {
+              quoteByPermalink: longQuote,
+            },
+          },
+        },
+      ];
+
+      const wrapper = ({ children }: { children: ReactNode }) => (
+        <MockedProvider mocks={mocks}>{children}</MockedProvider>
+      );
+
+      const { result } = renderHook(
+        () =>
+          useQuoteByPermalink(
+            'this-is-a-very-long-author-permalink',
+            'this-is-a-very-long-quote-permalink-with-many-words'
+          ),
+        { wrapper }
+      );
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.quote).toEqual(longQuote);
+      expect(result.current.error).toBeUndefined();
+    });
+  });
+});

--- a/src/hooks/useQuoteByPermalink.ts
+++ b/src/hooks/useQuoteByPermalink.ts
@@ -1,0 +1,29 @@
+import { useQuery } from '@apollo/client';
+import { GET_QUOTE_BY_PERMALINK } from '../graphql/queries';
+import { Quote } from '../types';
+
+interface QuoteBySlugData {
+  quoteByPermalink: Quote | null;
+}
+
+export function useQuoteByPermalink(
+  authorPermalink: string | undefined,
+  quotePermalink: string | undefined
+) {
+  const { loading, error, data } = useQuery<QuoteBySlugData>(
+    GET_QUOTE_BY_PERMALINK,
+    {
+      variables: {
+        author: authorPermalink,
+        permalink: quotePermalink,
+      },
+      skip: !authorPermalink || !quotePermalink,
+    }
+  );
+
+  return {
+    loading,
+    error,
+    quote: data?.quoteByPermalink,
+  };
+}

--- a/src/pages/ViewQuote/ViewQuote.test.tsx
+++ b/src/pages/ViewQuote/ViewQuote.test.tsx
@@ -5,7 +5,7 @@ import { MockedProvider } from '@apollo/client/testing';
 
 import { ViewQuote } from './ViewQuote';
 import {
-  GET_QUOTE_BY_ID,
+  GET_QUOTE_BY_PERMALINK,
   GET_RANDOM_QUOTE,
   GET_NEXT_QUOTE,
   GET_PREVIOUS_QUOTE,
@@ -46,6 +46,11 @@ describe('ViewQuote', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     mockNavigate.mockClear();
+    // Set default params for permalink-based routing
+    Object.assign(mockParams, {
+      authorPermalink: 'steve-jobs',
+      quotePermalink: 'test-quote',
+    });
   });
 
   afterEach(() => {
@@ -58,12 +63,12 @@ describe('ViewQuote', () => {
       const mocks = [
         {
           request: {
-            query: GET_QUOTE_BY_ID,
-            variables: { quoteId: 1 },
+            query: GET_QUOTE_BY_PERMALINK,
+            variables: { author: 'steve-jobs', permalink: 'test-quote' },
           },
           result: {
             data: {
-              quoteById: mockQuote,
+              quoteByPermalink: mockQuote,
             },
           },
           delay: 1000,
@@ -95,12 +100,12 @@ describe('ViewQuote', () => {
       const mocks = [
         {
           request: {
-            query: GET_QUOTE_BY_ID,
-            variables: { quoteId: 1 },
+            query: GET_QUOTE_BY_PERMALINK,
+            variables: { author: 'steve-jobs', permalink: 'test-quote' },
           },
           result: {
             data: {
-              quoteById: mockQuote,
+              quoteByPermalink: mockQuote,
             },
           },
         },
@@ -135,12 +140,12 @@ describe('ViewQuote', () => {
       const mocks = [
         {
           request: {
-            query: GET_QUOTE_BY_ID,
-            variables: { quoteId: 1 },
+            query: GET_QUOTE_BY_PERMALINK,
+            variables: { author: 'steve-jobs', permalink: 'test-quote' },
           },
           result: {
             data: {
-              quoteById: mockQuote,
+              quoteByPermalink: mockQuote,
             },
           },
         },
@@ -175,12 +180,12 @@ describe('ViewQuote', () => {
       const mocks = [
         {
           request: {
-            query: GET_QUOTE_BY_ID,
-            variables: { quoteId: 1 },
+            query: GET_QUOTE_BY_PERMALINK,
+            variables: { author: 'steve-jobs', permalink: 'test-quote' },
           },
           result: {
             data: {
-              quoteById: mockQuote,
+              quoteByPermalink: mockQuote,
             },
           },
         },
@@ -211,12 +216,12 @@ describe('ViewQuote', () => {
       const mocks = [
         {
           request: {
-            query: GET_QUOTE_BY_ID,
-            variables: { quoteId: 1 },
+            query: GET_QUOTE_BY_PERMALINK,
+            variables: { author: 'steve-jobs', permalink: 'test-quote' },
           },
           result: {
             data: {
-              quoteById: mockQuote,
+              quoteByPermalink: mockQuote,
             },
           },
         },
@@ -259,7 +264,7 @@ describe('ViewQuote', () => {
       jest.advanceTimersByTime(150);
 
       await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/quote/2', {
+        expect(mockNavigate).toHaveBeenCalledWith('/steve-jobs/test-quote-2', {
           replace: false,
         });
       });
@@ -271,8 +276,8 @@ describe('ViewQuote', () => {
       const mocks = [
         {
           request: {
-            query: GET_QUOTE_BY_ID,
-            variables: { quoteId: 1 },
+            query: GET_QUOTE_BY_PERMALINK,
+            variables: { author: 'steve-jobs', permalink: 'test-quote' },
           },
           error: new Error('GraphQL error'),
         },
@@ -305,12 +310,12 @@ describe('ViewQuote', () => {
       const mocks = [
         {
           request: {
-            query: GET_QUOTE_BY_ID,
-            variables: { quoteId: 1 },
+            query: GET_QUOTE_BY_PERMALINK,
+            variables: { author: 'steve-jobs', permalink: 'test-quote' },
           },
           result: {
             data: {
-              quoteById: null,
+              quoteByPermalink: null,
             },
           },
         },
@@ -340,12 +345,26 @@ describe('ViewQuote', () => {
     });
   });
 
-  describe('Invalid Quote ID', () => {
-    it('should handle invalid quote ID gracefully', async () => {
-      // Mock invalid ID
-      Object.assign(mockParams, { id: 'invalid' });
+  describe('Invalid Permalinks', () => {
+    it('should handle invalid permalinks gracefully', async () => {
+      // Mock invalid permalinks
+      Object.assign(mockParams, {
+        authorPermalink: 'invalid-author',
+        quotePermalink: 'invalid-quote',
+      });
 
       const mocks = [
+        {
+          request: {
+            query: GET_QUOTE_BY_PERMALINK,
+            variables: { author: 'invalid-author', permalink: 'invalid-quote' },
+          },
+          result: {
+            data: {
+              quoteByPermalink: null,
+            },
+          },
+        },
         {
           request: {
             query: GET_RANDOM_QUOTE,
@@ -364,13 +383,18 @@ describe('ViewQuote', () => {
         </MockedProvider>
       );
 
-      // Should not crash, and should handle the invalid ID
+      // Should redirect to not-found when quote is not found
       await waitFor(() => {
-        expect(screen.queryByText(/loading quote/i)).not.toBeInTheDocument();
+        expect(mockNavigate).toHaveBeenCalledWith('/not-found', {
+          replace: true,
+        });
       });
 
       // Reset mockParams
-      Object.assign(mockParams, { id: '1' });
+      Object.assign(mockParams, {
+        authorPermalink: 'steve-jobs',
+        quotePermalink: 'test-quote',
+      });
     });
   });
 
@@ -379,12 +403,12 @@ describe('ViewQuote', () => {
       const mocks = [
         {
           request: {
-            query: GET_QUOTE_BY_ID,
-            variables: { quoteId: 1 },
+            query: GET_QUOTE_BY_PERMALINK,
+            variables: { author: 'steve-jobs', permalink: 'test-quote' },
           },
           result: {
             data: {
-              quoteById: mockQuote,
+              quoteByPermalink: mockQuote,
             },
           },
         },
@@ -426,12 +450,12 @@ describe('ViewQuote', () => {
       const mocks = [
         {
           request: {
-            query: GET_QUOTE_BY_ID,
-            variables: { quoteId: 1 },
+            query: GET_QUOTE_BY_PERMALINK,
+            variables: { author: 'steve-jobs', permalink: 'test-quote' },
           },
           result: {
             data: {
-              quoteById: mockQuote,
+              quoteByPermalink: mockQuote,
             },
           },
         },
@@ -475,7 +499,7 @@ describe('ViewQuote', () => {
       jest.advanceTimersByTime(150);
 
       await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/quote/3', {
+        expect(mockNavigate).toHaveBeenCalledWith('/steve-jobs/test-quote-3', {
           replace: false,
         });
       });
@@ -487,12 +511,12 @@ describe('ViewQuote', () => {
       const mocks = [
         {
           request: {
-            query: GET_QUOTE_BY_ID,
-            variables: { quoteId: 1 },
+            query: GET_QUOTE_BY_PERMALINK,
+            variables: { author: 'steve-jobs', permalink: 'test-quote' },
           },
           result: {
             data: {
-              quoteById: mockQuote,
+              quoteByPermalink: mockQuote,
             },
           },
         },
@@ -534,12 +558,12 @@ describe('ViewQuote', () => {
       const mocks = [
         {
           request: {
-            query: GET_QUOTE_BY_ID,
-            variables: { quoteId: 1 },
+            query: GET_QUOTE_BY_PERMALINK,
+            variables: { author: 'steve-jobs', permalink: 'test-quote' },
           },
           result: {
             data: {
-              quoteById: mockQuote,
+              quoteByPermalink: mockQuote,
             },
           },
         },
@@ -583,7 +607,7 @@ describe('ViewQuote', () => {
       jest.advanceTimersByTime(150);
 
       await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/quote/0', {
+        expect(mockNavigate).toHaveBeenCalledWith('/steve-jobs/test-quote-0', {
           replace: false,
         });
       });

--- a/src/pages/ViewQuote/ViewQuote.tsx
+++ b/src/pages/ViewQuote/ViewQuote.tsx
@@ -5,7 +5,7 @@ import { Button } from '@tamagui/button';
 import { useParams, useNavigate } from 'react-router-dom';
 
 import {
-  useQuoteById,
+  useQuoteByPermalink,
   useRandomQuote,
   useNextQuote,
   usePreviousQuote,
@@ -14,13 +14,17 @@ import { QuoteDisplay } from '../../components';
 import { buildQuoteUrl } from '../../utils/permalinks';
 
 export function ViewQuote() {
-  const { id } = useParams<{ id: string }>();
+  const { authorPermalink, quotePermalink } = useParams<{
+    authorPermalink: string;
+    quotePermalink: string;
+  }>();
   const navigate = useNavigate();
   const [isAnimating, setIsAnimating] = useState(false);
 
-  const quoteId = id ? parseInt(id, 10) : null;
-
-  const { loading, error, quote } = useQuoteById(quoteId);
+  const { loading, error, quote } = useQuoteByPermalink(
+    authorPermalink,
+    quotePermalink
+  );
   const { refetch } = useRandomQuote();
   const { fetchNextQuote } = useNextQuote();
   const { fetchPreviousQuote } = usePreviousQuote();
@@ -43,10 +47,10 @@ export function ViewQuote() {
   };
 
   const getNextQuote = async () => {
-    if (!quoteId) return;
+    if (!quote?.id) return;
     setIsAnimating(true);
     try {
-      const result = await fetchNextQuote(quoteId);
+      const result = await fetchNextQuote(parseInt(quote.id, 10));
       if (result.data?.nextQuote) {
         const newUrl = buildQuoteUrl(result.data.nextQuote);
         navigate(newUrl, { replace: false });
@@ -59,10 +63,10 @@ export function ViewQuote() {
   };
 
   const getPreviousQuote = async () => {
-    if (!quoteId) return;
+    if (!quote?.id) return;
     setIsAnimating(true);
     try {
-      const result = await fetchPreviousQuote(quoteId);
+      const result = await fetchPreviousQuote(parseInt(quote.id, 10));
       if (result.data?.prevQuote) {
         const newUrl = buildQuoteUrl(result.data.prevQuote);
         navigate(newUrl, { replace: false });

--- a/src/utils/permalinks.test.ts
+++ b/src/utils/permalinks.test.ts
@@ -3,7 +3,7 @@ import { Quote } from '../types';
 
 describe('buildQuoteUrl', () => {
   describe('Valid Quote', () => {
-    it('should build correct URL for a quote', () => {
+    it('should build correct URL using author and quote permalinks', () => {
       const quote: Quote = {
         id: '1',
         quote: 'The only way to do great work is to love what you do.',
@@ -16,10 +16,10 @@ describe('buildQuoteUrl', () => {
       };
 
       const url = buildQuoteUrl(quote);
-      expect(url).toBe('/quote/1');
+      expect(url).toBe('/steve-jobs/test-quote');
     });
 
-    it('should build correct URL for a quote with different ID', () => {
+    it('should build correct URL for a quote with different permalinks', () => {
       const quote: Quote = {
         id: '42',
         quote: 'Another quote',
@@ -32,10 +32,10 @@ describe('buildQuoteUrl', () => {
       };
 
       const url = buildQuoteUrl(quote);
-      expect(url).toBe('/quote/42');
+      expect(url).toBe('/author-name/another-quote');
     });
 
-    it('should handle numeric string IDs', () => {
+    it('should use permalinks regardless of IDs', () => {
       const quote: Quote = {
         id: '999',
         quote: 'Test quote',
@@ -48,12 +48,12 @@ describe('buildQuoteUrl', () => {
       };
 
       const url = buildQuoteUrl(quote);
-      expect(url).toBe('/quote/999');
+      expect(url).toBe('/test-author/test');
     });
   });
 
   describe('URL Format', () => {
-    it('should start with /quote/', () => {
+    it('should follow /{author-permalink}/{quote-permalink} format', () => {
       const quote: Quote = {
         id: '1',
         quote: 'Test',
@@ -66,10 +66,11 @@ describe('buildQuoteUrl', () => {
       };
 
       const url = buildQuoteUrl(quote);
-      expect(url).toMatch(/^\/quote\//);
+      expect(url).toMatch(/^\/[^/]+\/[^/]+$/);
+      expect(url).toBe('/author/test');
     });
 
-    it('should only use quote ID in URL', () => {
+    it('should use permalinks, not IDs or raw text', () => {
       const quote: Quote = {
         id: '123',
         quote: 'This is a test quote with special chars!@#$%',
@@ -82,43 +83,82 @@ describe('buildQuoteUrl', () => {
       };
 
       const url = buildQuoteUrl(quote);
-      expect(url).toBe('/quote/123');
-      expect(url).not.toContain('this-is-a-test-quote');
-      expect(url).not.toContain('author');
+      expect(url).toBe(
+        '/author-with-special-chars/this-is-a-test-quote-with-special-chars'
+      );
+      expect(url).not.toContain('123');
+      expect(url).not.toContain('456');
+      expect(url).not.toContain('!@#$%');
+    });
+
+    it('should include both author and quote permalinks', () => {
+      const quote: Quote = {
+        id: '1',
+        quote: 'Test',
+        permalink: 'my-quote',
+        author: {
+          id: '1',
+          name: 'Author',
+          permalink: 'my-author',
+        },
+      };
+
+      const url = buildQuoteUrl(quote);
+      expect(url).toContain('my-author');
+      expect(url).toContain('my-quote');
+      expect(url.split('/').length).toBe(3); // Empty string, author, quote
     });
   });
 
   describe('Edge Cases', () => {
-    it('should handle single digit IDs', () => {
+    it('should handle short permalinks', () => {
       const quote: Quote = {
         id: '1',
         quote: 'Test',
-        permalink: 'test',
+        permalink: 'a',
         author: {
           id: '1',
           name: 'Author',
-          permalink: 'author',
+          permalink: 'b',
         },
       };
 
       const url = buildQuoteUrl(quote);
-      expect(url).toBe('/quote/1');
+      expect(url).toBe('/b/a');
     });
 
-    it('should handle large numeric IDs', () => {
+    it('should handle long permalinks', () => {
       const quote: Quote = {
         id: '999999999',
         quote: 'Test',
-        permalink: 'test',
+        permalink: 'this-is-a-very-long-quote-permalink-with-many-words',
         author: {
           id: '1',
           name: 'Author',
-          permalink: 'author',
+          permalink: 'this-is-a-very-long-author-permalink',
         },
       };
 
       const url = buildQuoteUrl(quote);
-      expect(url).toBe('/quote/999999999');
+      expect(url).toBe(
+        '/this-is-a-very-long-author-permalink/this-is-a-very-long-quote-permalink-with-many-words'
+      );
+    });
+
+    it('should handle permalinks with hyphens', () => {
+      const quote: Quote = {
+        id: '1',
+        quote: 'Test',
+        permalink: 'quote-with-many-hyphens',
+        author: {
+          id: '1',
+          name: 'Author',
+          permalink: 'author-name-with-hyphens',
+        },
+      };
+
+      const url = buildQuoteUrl(quote);
+      expect(url).toBe('/author-name-with-hyphens/quote-with-many-hyphens');
     });
   });
 });

--- a/src/utils/permalinks.ts
+++ b/src/utils/permalinks.ts
@@ -2,8 +2,8 @@ import { Quote } from '../types';
 
 /**
  * Builds a quote URL from a quote object
- * Format: /quote/{id}
+ * Format: /{author-permalink}/{quote-slug}
  */
 export function buildQuoteUrl(quote: Quote): string {
-  return `/quote/${quote.id}`;
+  return `/${quote.author.permalink}/${quote.permalink}`;
 }


### PR DESCRIPTION
This change sets up the routing structure of `/{author-name}/{quote-slug}/` for quotes.

**How to test:**

- [ ] Checkout this branch locally
- [ ] Open the homepage
- [ ] Click 'Random' or 'New Quote'
- [ ] Verify the url matches the structure `/{author-name}/{quote-slug}/`